### PR TITLE
Fix a bug for the CULane metric

### DIFF
--- a/culane_metric/evaluate.py
+++ b/culane_metric/evaluate.py
@@ -19,6 +19,7 @@ metric is used.
 
 import os
 import argparse
+import warnings
 from functools import partial
 
 import cv2
@@ -85,11 +86,12 @@ def continuous_cross_iou(xs, ys, width=30):
     return ious
 
 
-def remove_con_dup(x):
-    """Customize a set op to remove consecutive duplications"""
+def remove_consecutive_duplicates(x):
+    """Remove consecutive duplicates"""
     y = []
     for t in x:
         if len(y) > 0 and y[-1] == t:
+            warnings.warn('Removed consecutive duplicate point ({}, {})!'.format(t[0], t[1]))
             continue
         y.append(t)
     return y
@@ -97,10 +99,10 @@ def remove_con_dup(x):
 
 def interpolate_lane(points, n=50):
     """Spline interpolation of a lane. Used on the predictions"""
-    # Consecutive duplications (can happen with parametric curves)
+    # Consecutive duplicates (can happen with parametric curves)
     # cause internal error for scipy's splprep:
     # https://stackoverflow.com/a/47949170/15449902
-    points = remove_con_dup(points)
+    points = remove_consecutive_duplicates(points)
 
     # B-Spline interpolate
     x = [x for x, _ in points]

--- a/culane_metric/evaluate.py
+++ b/culane_metric/evaluate.py
@@ -85,8 +85,24 @@ def continuous_cross_iou(xs, ys, width=30):
     return ious
 
 
+def remove_con_dup(x):
+    """Customize a set op to remove consecutive duplications"""
+    y = []
+    for t in x:
+        if len(y) > 0 and y[-1] == t:
+            continue
+        y.append(t)
+    return y
+
+
 def interpolate_lane(points, n=50):
     """Spline interpolation of a lane. Used on the predictions"""
+    # Consecutive duplications (can happen with parametric curves)
+    # cause internal error for scipy's splprep:
+    # https://stackoverflow.com/a/47949170/15449902
+    points = remove_con_dup(points)
+
+    # B-Spline interpolate
     x = [x for x, _ in points]
     y = [y for _, y in points]
     tck, _ = splprep([x, y], s=0, t=n, k=min(3, len(points) - 1))


### PR DESCRIPTION
Consecutive duplications can cause an internal error for scipy's `splprep`:
https://stackoverflow.com/a/47949170/15449902

For instance, this happened when fitting order-4 Bézier curve to one lane in the val set with limited precision:

```
from scipy.interpolate import splprep, splev
x = [649.125, 643.983, 638.176, 631.75, 624.749, 617.219, 609.201, 600.737, 591.869, 582.635, 573.076, 563.227, 553.126, 542.809, 532.308, 521.659, 510.893, 500.04, 489.132, 478.197, 467.263, 456.357, 445.504, 434.731, 424.059, 413.512, 403.11, 392.876, 382.827, 372.983, 363.36, 353.974, 344.841, 335.975, 327.388, 319.093, 311.1, 303.418, 296.057, 289.025, 282.327, 275.968, 269.955, 264.289, 258.972, 254.007, 249.393, 245.129, 241.213, 237.642, 234.411, 231.516, 228.95, 226.705, 224.774, 223.146, 221.81, 220.756, 219.971, 219.44, 219.148, 219.08, 219.219, 219.546, 220.042, 220.687, 221.46, 222.338, 223.297, 224.313, 225.361, 226.413, 227.443, 228.42, 229.316, 230.098, 230.736, 231.196, 231.443, 231.443, 231.159, 230.553, 229.588, 228.224, 226.419, 224.132, 221.322, 217.942, 213.95, 209.298, 203.939, 197.827, 190.91, 183.14, 174.464, 164.831, 154.186, 142.476, 129.644, 115.634]
y = [368.0, 368.0, 369.0, 369.0, 369.0, 369.0, 370.0, 370.0, 370.0, 371.0, 371.0, 372.0, 372.0, 373.0, 373.0, 374.0, 375.0, 375.0, 376.0, 376.0, 377.0, 378.0, 378.0, 379.0, 380.0, 380.0, 381.0, 382.0, 382.0, 383.0, 383.0, 384.0, 385.0, 385.0, 386.0, 386.0, 387.0, 387.0, 388.0, 389.0, 389.0, 390.0, 390.0, 390.0, 391.0, 391.0, 392.0, 392.0, 392.0, 393.0, 393.0, 393.0, 394.0, 394.0, 394.0, 395.0, 395.0, 395.0, 395.0, 395.0, 396.0, 396.0, 396.0, 396.0, 396.0, 397.0, 397.0, 397.0, 397.0, 397.0, 397.0, 398.0, 398.0, 398.0, 398.0, 398.0, 399.0, 399.0, 399.0, 399.0, 400.0, 400.0, 400.0, 401.0, 401.0, 402.0, 402.0, 403.0, 403.0, 404.0, 405.0, 405.0, 406.0, 407.0, 408.0, 409.0, 410.0, 411.0, 412.0, 413.0]

tck, _ = splprep([x, y], s=0, t=50, k=min(3, len(x) - 1))
```

This results in the following error:
```
ValueError: Invalid inputs.
```

The reason is this segment:

```
x = [231.443, 231.443]
y = [399.0, 399.0]
```

I've added some codes to make the evaluation script more robust. Although one alternative is to raise errors and let users process their inputs themselves, getting this done in the evaluation script seems better.

cc @karstenBehrendt @lucastabelini 